### PR TITLE
Allowing execution with no arguments

### DIFF
--- a/src/com/dumbster/smtp/Main.java
+++ b/src/com/dumbster/smtp/Main.java
@@ -14,7 +14,7 @@ public class Main {
 
     private static boolean shouldShowHelp(String[] args) {
         if (args.length == 0)
-            return true;
+            return false;
         for (String arg : args) {
             if ("--help".equalsIgnoreCase(arg) || "-h".equalsIgnoreCase(arg))
                 return true;


### PR DESCRIPTION
According to help message arguments are optional, so we shouldn't show the help message if no argument is given.
