### PR TITLE
Accept timed out

### DIFF
--- a/src/com/dumbster/smtp/SmtpServer.java
+++ b/src/com/dumbster/smtp/SmtpServer.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executors;
  */
 public class SmtpServer implements Runnable {
     public static final int DEFAULT_SMTP_PORT = 25;
-    private static final int SERVER_SOCKET_TIMEOUT = 5000;
+    private static final int SERVER_SOCKET_TIMEOUT = 0;
     private static final int MAX_THREADS = 10;
 
     private volatile MailStore mailStore;

--- a/src/com/dumbster/smtp/mailstores/EMLMailStore.java
+++ b/src/com/dumbster/smtp/mailstores/EMLMailStore.java
@@ -90,10 +90,7 @@ public class EMLMailStore implements MailStore {
                 System.out.println("Directory created: " + directory);
                 directory.mkdirs();
             }
-            String filename = new StringBuilder().append(count).append("_")
-                    .append(message.getFirstHeaderValue("Subject"))
-                    .append(".eml").toString();
-            filename = filename.replaceAll("[\\\\/<>\\?>\\*\"\\|]", "_");
+            String filename = getFilename(message, count);
             File file = new File(directory, filename);
             FileWriter writer = new FileWriter(file);
 
@@ -117,6 +114,14 @@ public class EMLMailStore implements MailStore {
             System.err.println(e.getMessage());
             e.printStackTrace();
         }
+    }
+
+    public String getFilename(MailMessage message, int count) {
+        String filename = new StringBuilder().append(count).append("_")
+                .append(message.getFirstHeaderValue("Subject"))
+                .append(".eml").toString();
+        filename = filename.replaceAll("[\\\\/<>\\?>\\*\"\\|]", "_");
+        return filename;
     }
 
     /**

--- a/test-src/com/dumbster/smtp/eml/EMLMailStoreTest.java
+++ b/test-src/com/dumbster/smtp/eml/EMLMailStoreTest.java
@@ -1,21 +1,18 @@
 package com.dumbster.smtp.eml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.IOException;
-
+import com.dumbster.smtp.MailMessage;
+import com.dumbster.smtp.MailMessageImpl;
 import com.dumbster.smtp.mailstores.EMLMailStore;
+import com.dumbster.smtp.mailstores.EMLMailStore.EMLFilenameFilter;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.dumbster.smtp.MailMessage;
-import com.dumbster.smtp.MailMessageImpl;
-import com.dumbster.smtp.mailstores.EMLMailStore.EMLFilenameFilter;
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+
+import static org.junit.Assert.*;
 
 public class EMLMailStoreTest {
 
@@ -25,8 +22,21 @@ public class EMLMailStoreTest {
     @Before
     public void setup() {
         mailStore = new EMLMailStore();
-        emlStoreDir = new File("build/test/eml_store_test");
+        emlStoreDir = new File("build/test/eml_store_test" + String.valueOf(new Random().nextInt(1000000)));
         mailStore.setDirectory(emlStoreDir);
+    }
+
+    @After
+    public void tearDown() {
+        int count = 1;
+        for (MailMessage message : mailStore.getMessages()) {
+            String filename = mailStore.getFilename(message, count++);
+            new File(emlStoreDir, filename).delete();
+        }
+        mailStore.clearMessages();
+        deleteTheTwoMessages();
+
+        emlStoreDir.delete();
     }
 
     @Test
@@ -45,6 +55,11 @@ public class EMLMailStoreTest {
         givenMailStoreDirectoryHasTwoMessages();
 
         assertEquals(2, mailStore.getEmailCount());
+    }
+
+    private void deleteTheTwoMessages() {
+        new File(emlStoreDir, "1_message.eml").delete();
+        new File(emlStoreDir, "2_message.eml").delete();
     }
 
 


### PR DESCRIPTION
When I start Dumbster, the Server listens for 5 Seconds and then presents a
java.net.SocketTimeoutException: Accept timed out

This is probably related to #13 since when exceptions on accept terminate the whole application.
The ServerSockets timeout is set to 5 Seconds and after that, the accept-call interrupts / times out and this exception terminates the application. It may be acceptable for Unittests, but makes it impossible to run Dumbster longer than 5 Seconds without an accepted request.

This PR removes the timeout completely so that the server can be used as long as it is not stopped or interrupted. The stop-method still works because it calls serverSocket.close() and this will interrupt the serverSocket even if it doesn't time out.

The changes for EMLMailStore and EMLMailStoreTest are not directly related but were neccessary to make the test running stable on my system.
Somehow the method EMLMailStoreTest::givenMailStoreDirectoryIsEmpty doesn't remove all files or some files are written by the previous EMLMailStore with delay, but when running the whole EMLMailStoreTest suite, some tests are always failing because there are files left from another test.
These PR changes do 2 things:
1. use a differen directory for each test
2. clean the directory on tearDown (mailStore.clearMessages seems to avoid a delayed write)
