### PR TITLE
BlockingQueueMailStore

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -14,6 +14,7 @@ Forked from http://quintanasoft.com/dumbster/ version 1.6 by Jason Kitchen
 * Improved test coverage
 * telnet to smtp server and use "list" command to view number of msgs
 * use list command with an index 0..(size-1) of messages to view a message
+* Support testing of asynchronous mail transfer with BlockingQueueMailStore
 
 EXAMPLE (SMTP unit testing fake)
 public class SmtpServerTest extends TestCase {

--- a/src/com/dumbster/smtp/mailstores/BlockingQueueMailStore.java
+++ b/src/com/dumbster/smtp/mailstores/BlockingQueueMailStore.java
@@ -1,0 +1,110 @@
+/**
+ * 
+ */
+package com.dumbster.smtp.mailstores;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import com.dumbster.smtp.MailMessage;
+import com.dumbster.smtp.MailStore;
+import com.dumbster.smtp.ServerOptions;
+import com.dumbster.smtp.SmtpServerFactory;
+
+/**
+ * MailStore which is backed by a BlockingQueue.
+ * 
+ * If you want to test asynchronous mail transport you can use
+ * the queue's {@link BlockingQueue#take()} method.
+ *
+ * @author markus@malkusch.de
+ * @see BlockingQueue
+ * @see SmtpServerFactory#startServer(ServerOptions)
+ * @see ServerOptions#mailStore
+ */
+public class BlockingQueueMailStore implements MailStore {
+	
+	private BlockingQueue<MailMessage> queue;
+	
+	private long timeout;
+	
+	private TimeUnit timeoutUnit;
+	
+	/**
+	 * Initializes with a LinkedBlockingQueue.
+	 * 
+	 * @see LinkedBlockingQueue
+	 */
+	public BlockingQueueMailStore() {
+		this(new LinkedBlockingQueue<MailMessage>());
+	}
+	
+	/**
+	 * Sets the Queue
+	 */
+	public BlockingQueueMailStore(BlockingQueue<MailMessage> queue) {
+		this.queue = queue;
+	}
+	
+	/**
+	 * Returns the queue
+	 */
+	public BlockingQueue<MailMessage> getQueue() {
+		return queue;
+	}
+	
+	/**
+	 * Sets an optional timeout for adding to the queue.
+	 * 
+	 * Set timeout to 0 if you don't want a timeout.
+	 */
+	public void setTimeout(long timeout, TimeUnit unit) {
+		this.timeout = timeout;
+		this.timeoutUnit = unit;
+	}
+	
+	/**
+	 * Returns whether adding to the queue has a timeout.
+	 */
+	public boolean isTimeout() {
+		return timeout != 0;
+	}
+	
+	@Override
+	public int getEmailCount() {
+		return this.queue.size();
+	}
+
+	@Override
+	public void addMessage(MailMessage message) {
+		try {
+			if (isTimeout()) {
+				queue.offer(message, timeout, timeoutUnit);
+				
+			} else {
+				queue.put(message);
+				
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			
+		}
+	}
+
+	@Override
+	public MailMessage[] getMessages() {
+		return queue.toArray(new MailMessage[]{});
+	}
+
+	@Override
+	public MailMessage getMessage(int index) {
+		return getMessages()[index];
+	}
+
+	@Override
+	public void clearMessages() {
+		queue.clear();
+	}
+
+}

--- a/test-src/com/dumbster/smtp/BlockingMailStoreTest.java
+++ b/test-src/com/dumbster/smtp/BlockingMailStoreTest.java
@@ -1,0 +1,103 @@
+package com.dumbster.smtp;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.dumbster.smtp.mailstores.BlockingQueueMailStore;
+
+/**
+ * Tests the BlockingQueueMailStore
+ *
+ * @author markus@malkusch.de
+ * @see BlockingQueueMailStore
+ */
+public class BlockingMailStoreTest {
+	
+	private BlockingQueueMailStore mailStore;
+	
+	@Before
+	public void setup() {
+		mailStore = new BlockingQueueMailStore();
+	}
+	
+	@Test
+	public void testGetMessage() {
+		MailMessage message0 = addAMessage();
+		assertSame(message0, mailStore.getMessage(0));
+		
+		MailMessage message1 = addAMessage();
+		MailMessage message2 = addAMessage();
+		
+		assertSame(message0, mailStore.getMessage(0));
+		assertSame(message1, mailStore.getMessage(1));
+		assertSame(message2, mailStore.getMessage(2));
+	}
+	
+	@Test
+	public void testTakeAfterAddMessage() throws InterruptedException {
+		MailMessage message = addAMessage();
+		assertSame(message, mailStore.getQueue().take());
+	}
+	
+	@Test
+	public void testTakeBeforeAddMessage() throws InterruptedException {
+		new Thread(new Runnable() {
+			
+			@Override
+			public void run() {
+				try {
+					Thread.sleep(1000);
+					
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				addAMessage();
+			}
+		}).start();
+		
+		assertEquals(0, mailStore.getEmailCount());
+		assertNotNull(mailStore.getQueue().take());
+	}
+	
+	@Test
+	public void testGetMessagesPreseversQueue() {
+		MailMessage[] messages = new MailMessage[3];
+		messages[0] = addAMessage();
+		assertArrayEquals(Arrays.copyOf(messages, 1), mailStore.getMessages());
+		
+		messages[1] = addAMessage();
+		messages[2] = addAMessage();
+		assertArrayEquals(Arrays.copyOf(messages, 3), mailStore.getMessages());
+	}
+	
+	@Test
+	public void testTakeDecreasesEmailCount() throws InterruptedException {
+		addAMessage();
+		addAMessage();
+		addAMessage();
+		assertEquals(3, mailStore.getEmailCount());
+		
+		mailStore.getQueue().take();
+		assertEquals(2, mailStore.getEmailCount());
+		
+		mailStore.getQueue().take();
+		assertEquals(1, mailStore.getEmailCount());
+		
+		mailStore.getQueue().take();
+		assertEquals(0, mailStore.getEmailCount());
+	}
+	
+	private MailMessage addAMessage() {
+        MailMessage message = new MailMessageImpl();
+        mailStore.addMessage(message);
+        return message;
+    }
+
+}


### PR DESCRIPTION
I implemented a `BlockingQueueMailStore` for supporting testing of asynchronous mail transfer. Just now while submitting the PR I discovered your `SmtpServer.anticipateMessageCountFor()` which is pretty much for the identical use case. You'll probably reject that PR.
